### PR TITLE
Disable CH552 internal pull-up resistors for G0/EN pins.

### DIFF
--- a/Debug.C
+++ b/Debug.C
@@ -142,6 +142,9 @@ void mInitSTDIO( )
     UINT32 x;
     UINT8 x2; 
 
+    // Configure TXD1/CAP1 pins, which are used for controlling EN/G0 pins, to open-drain with no pull-up resistor.
+    P1_DIR_PU = (P1_DIR_PU & ~(bTXD1 | bCAP1));
+
     SM0 = 0;
     SM1 = 1;
     SM2 = 0;                                                                   //串口0使用模式1


### PR DESCRIPTION
This PR disables internal pull-up resistors for TXD1 and CAP1 pins to avoid applying higher voltages to ESP32 G0/EN pins.

Since I did not try this code actually works because I cannot build the sources in this repository with SDCC, but I've confirmed that this modification works well with SDCC version of FT232BM compatible firmware (https://github.com/diodep/ch55x_esp/)